### PR TITLE
self-profile: add LD_PRELOAD Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,22 @@
 CFLAGS=-O -Wno-unused-result
+
+all: test_profile self-profile preload_test_profile bsearch
+
 test_profile: test_profile.o
+
+self-profile:
+	$(CC) self-profile.c -o self-profile.so -fPIC -shared -ldl
+
+preload_test_profile: preload_test_profile.o
+
+bsearch: bsearch.o
 
 .PHONY: clean
 clean:
-	rm test_profile test_profile.o
+	rm test_profile test_profile.o self-profile.so preload_test_profile.o preload_test_profile bsearch.o bsearch
 
 .PHONY: run
 run: test_profile
 	export PERF_COUNT_HW_CPU_CYCLES=1; ./test_profile
+	export PERF_COUNT_HW_CPU_CYCLES=1; LD_PRELOAD=self-profile.so ./preload_test_profile
+	export PERF_COUNT_HW_CPU_CYCLES=1; LD_PRELOAD=self-profile.so ./bsearch

--- a/bsearch.c
+++ b/bsearch.c
@@ -1,0 +1,39 @@
+/*
+ * Reference:
+ *  - https://man7.org/linux/man-pages/man3/bsearch.3.html
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+struct mi {
+    int nr;
+    char *name;
+} months[] = {
+    { 1, "jan" }, { 2, "feb" }, { 3, "mar" }, { 4, "apr" },
+    { 5, "may" }, { 6, "jun" }, { 7, "jul" }, { 8, "aug" },
+    { 9, "sep" }, {10, "oct" }, {11, "nov" }, {12, "dec" }
+};
+#define nr_of_months (sizeof(months)/sizeof(months[0]))
+static int
+compmi(const void *m1, const void *m2)
+{
+    struct mi *mi1 = (struct mi *) m1;
+    struct mi *mi2 = (struct mi *) m2;
+    return strcmp(mi1->name, mi2->name);
+}
+int
+main(int argc, char **argv)
+{
+    int i;
+    qsort(months, nr_of_months, sizeof(struct mi), compmi);
+    for (i = 1; i < argc; i++) {
+        struct mi key, *res;
+        key.name = argv[i];
+        res = bsearch(&key, months, nr_of_months,
+                      sizeof(struct mi), compmi);
+        if (res == NULL)
+            return 1;
+    }
+    return 0;
+}

--- a/preload_test_profile.c
+++ b/preload_test_profile.c
@@ -1,0 +1,44 @@
+#define _GNU_SOURCE
+#include <stdlib.h>
+
+/*
+       void qsort_r(void *base, size_t nmemb, size_t size,
+                  int (*compar)(const void *, const void *, void *),
+                  void *arg);
+ */
+
+struct item {
+    char *name;
+    int id;
+    double rating;
+} items[] = {
+    { "A", 157, 0.9 },
+    { "B", 517, 0.9 },
+    { "C", 175, 0.9 },
+    { "D", 571, 0.9 },
+    { "E", 127, 0.9 },
+    { "F", 147, 0.9 },
+    { "G", 117, 0.9 },
+    { "H", 107, 0.9 },
+    { "I", 111, 0.9 },
+    { "J", 227, 0.9 },
+    { "K", 157, 0.9 },
+    { "L", 157, 0.9 },
+    { "M", 157, 0.9 },
+    { "N", 157, 0.9 },
+    { "O", 157, 0.9 },
+    { "P", 157, 0.9 },
+    { "Z", 157, 0.9 }
+};
+
+int compare_items(const void *a, const void *b, void *arg) {
+    const struct item *itemL = a, *itemR = b;
+    if (itemL->id < itemR->id) return -1;
+    if (itemL->id > itemR->id) return 1;
+    return 0;
+}
+
+int main() {
+    qsort_r(items, sizeof(items)/sizeof(items[0]), sizeof(items[0]), compare_items, 0);
+    return 0;
+}

--- a/self-profile.c
+++ b/self-profile.c
@@ -1,0 +1,56 @@
+#define _GNU_SOURCE
+#include "self-profile.h"
+
+/*
+ * Reference:
+ *  Hook main() using LD_PRELOAD:
+ *  - https://gist.github.com/apsun/1e144bf7639b22ff0097171fa0f8c6b1
+ *  Using makefile, LD_PRELOAD to executable file:
+ *  - https://stackoverflow.com/questions/30594838/using-makefile-ld-preload-to-executable-file
+ */
+
+/* Trampoline for the real main() */
+static int (*main_orig)(int, char **, char **);
+
+/* main() that gets called by __libc_start_main() */
+int main_hook(int argc, char **argv, char **envp)
+{
+    PROFILE_BEGIN();
+    printf("Sorting...\n");
+    PROFILE_START();
+    int ret = main_orig(argc, argv, envp);
+    PROFILE_STOP();
+    /*
+     * I'm a bit concerned about this part of the code.
+     * It would be great if we could use the output section universally like main function.
+     * I'll think about it a bit more.
+     */
+    PROFILE_REPORT();
+    PROFILE_END();
+
+    return ret;
+}
+
+/*
+ * Wrapper for __libc_start_main() that replaces the real main
+ * function with our hooked version.
+ */
+int __libc_start_main(
+    int (*main)(int, char **, char **),
+    int argc,
+    char **argv,
+    int (*init)(int, char **, char **),
+    void (*fini)(void),
+    void (*rtld_fini)(void),
+    void *stack_end)
+{
+    /* Save the real main function address */
+    main_orig = main;
+
+    /* Find the real __libc_start_main()... */
+    typeof(&__libc_start_main) orig = dlsym(RTLD_NEXT, "__libc_start_main");
+
+    /* ... and call it with our custom main function */
+    return orig(main_hook, argc, argv, init, fini, rtld_fini, stack_end);
+}
+

--- a/self-profile.h
+++ b/self-profile.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <dlfcn.h>
 #include <sys/ioctl.h>
 #include <linux/perf_event.h>
 #include <asm/unistd.h>


### PR DESCRIPTION
This code is a simple implementation of my idea in #1 , with a focus on making the self-profile's portability.
It seems useful, even if there's a call to the main function, because This method seems to reduce overhead compared to using `perf record` directly. We can directly insert the code according to its original purpose.

Here are the test results from my Raspberry Pi 5, gcc version 12.2.0 (Debian 12.2.0-14)
```
$ uname -a
Linux paran 6.10.1-v8-16k+ #1 SMP PREEMPT Sat Jul 27 17:52:03 KST 2024 aarch64 GNU/Linux

$ make run
export PERF_COUNT_HW_CPU_CYCLES=1; ./test_profile
Sorting...
00: { "H", 107, 0.900000 }
01: { "I", 111, 0.900000 }
02: { "G", 117, 0.900000 }
03: { "E", 127, 0.900000 }
04: { "F", 147, 0.900000 }
05: { "A", 157, 0.900000 }
06: { "K", 157, 0.900000 }
07: { "L", 157, 0.900000 }
08: { "M", 157, 0.900000 }
09: { "N", 157, 0.900000 }
10: { "O", 157, 0.900000 }
11: { "P", 157, 0.900000 }
12: { "Z", 157, 0.900000 }
13: { "C", 175, 0.900000 }
14: { "J", 227, 0.900000 }
15: { "B", 517, 0.900000 }
16: { "D", 571, 0.900000 }
PERF_COUNT_HW_CPU_CYCLES(0): 7970
export PERF_COUNT_HW_CPU_CYCLES=1; LD_PRELOAD=self-profile.so ./preload_test_profile
Sorting...
PERF_COUNT_HW_CPU_CYCLES(0): 7444
export PERF_COUNT_HW_CPU_CYCLES=1; LD_PRELOAD=self-profile.so ./bsearch
Sorting...
PERF_COUNT_HW_CPU_CYCLES(0): 6779
```